### PR TITLE
feat: add screen guard during task execution

### DIFF
--- a/backend/app/models/device_config.py
+++ b/backend/app/models/device_config.py
@@ -16,6 +16,9 @@ class DeviceConfig(Base):
     # 唤醒命令类型: keyevent (默认使用 KEYCODE_WAKEUP)
     wake_command: Mapped[str | None] = mapped_column(Text, nullable=True)
 
+    # 屏幕守护：在任务执行过程中（每次截图前/动作执行前）检测并必要时唤醒/解锁
+    screen_guard_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
+
     # 解锁配置
     unlock_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
     # 解锁类型: swipe (滑动) 或 longpress (长按)

--- a/backend/app/schemas/device_config.py
+++ b/backend/app/schemas/device_config.py
@@ -7,6 +7,7 @@ class DeviceConfigBase(BaseModel):
     device_serial: str = Field(..., max_length=100)
     wake_enabled: bool = True
     wake_command: str | None = None
+    screen_guard_enabled: bool = False
     unlock_enabled: bool = False
     unlock_type: Literal["swipe", "longpress"] | None = None
     unlock_start_x: int | None = None
@@ -23,6 +24,7 @@ class DeviceConfigCreate(DeviceConfigBase):
 class DeviceConfigUpdate(BaseModel):
     wake_enabled: bool | None = None
     wake_command: str | None = None
+    screen_guard_enabled: bool | None = None
     unlock_enabled: bool | None = None
     unlock_type: Literal["swipe", "longpress"] | None = None
     unlock_start_x: int | None = None

--- a/backend/app/services/screen_guard.py
+++ b/backend/app/services/screen_guard.py
@@ -4,6 +4,8 @@ import threading
 import time
 from dataclasses import dataclass
 
+from app.services.adb import get_adb_command
+
 logger = logging.getLogger(__name__)
 
 
@@ -33,7 +35,7 @@ def get_screen_guard_config() -> ScreenGuardConfig | None:
 
 
 def _adb_cmd_prefix(device_id: str | None) -> list[str]:
-    cmd = ["adb"]
+    cmd = get_adb_command()
     if device_id:
         cmd.extend(["-s", device_id])
     return cmd
@@ -174,4 +176,3 @@ def ensure_device_awake(device_id: str | None) -> None:
                 time.sleep(0.5)
 
         raise RuntimeError(f"设备解锁失败：重试 {max_retries} 次后仍处于锁屏状态")
-

--- a/backend/app/services/screen_guard.py
+++ b/backend/app/services/screen_guard.py
@@ -1,0 +1,177 @@
+import logging
+import subprocess
+import threading
+import time
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ScreenGuardConfig:
+    enabled: bool = False
+    wake: bool = True
+    unlock: bool = True
+    wake_command: str | None = None
+    unlock_type: str | None = None  # "swipe" | "longpress"
+    unlock_start_x: int | None = None
+    unlock_start_y: int | None = None
+    unlock_end_x: int | None = None
+    unlock_end_y: int | None = None
+    unlock_duration: int = 300
+
+
+_thread_local = threading.local()
+
+
+def set_screen_guard_config(config: ScreenGuardConfig | None) -> None:
+    _thread_local.screen_guard_config = config
+
+
+def get_screen_guard_config() -> ScreenGuardConfig | None:
+    return getattr(_thread_local, "screen_guard_config", None)
+
+
+def _adb_cmd_prefix(device_id: str | None) -> list[str]:
+    cmd = ["adb"]
+    if device_id:
+        cmd.extend(["-s", device_id])
+    return cmd
+
+
+def _run_adb_shell(
+    device_id: str | None,
+    *args: str,
+    timeout: float = 10.0,
+) -> str:
+    cmd = _adb_cmd_prefix(device_id)
+    cmd.extend(["shell", *args])
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    return (proc.stdout or "") + (proc.stderr or "")
+
+
+def _is_screen_locked(device_id: str | None) -> tuple[bool, bool]:
+    """
+    检测屏幕是否锁定
+    返回: (屏幕是否亮着, 是否在锁屏界面)
+    """
+    try:
+        screen_on = False
+        is_locked = False
+
+        # 方法1: window policy（较准确）
+        try:
+            policy_output = _run_adb_shell(device_id, "dumpsys", "window", "policy")
+            if "mScreenOnFully=true" in policy_output:
+                screen_on = True
+            if "mInputRestricted=true" in policy_output:
+                is_locked = True
+        except Exception:
+            pass
+
+        # 方法2: power 状态（补充屏幕亮灭判断）
+        if not screen_on:
+            try:
+                power_output = _run_adb_shell(device_id, "dumpsys", "power")
+                if any(
+                    x in power_output
+                    for x in (
+                        "mWakefulness=Awake",
+                        "Display Power: state=ON",
+                        "mHoldingDisplaySuspendBlocker=true",
+                    )
+                ):
+                    screen_on = True
+                if "mWakefulness=Asleep" in power_output or "mWakefulness=Dozing" in power_output:
+                    screen_on = False
+            except Exception:
+                pass
+
+        # 方法3: window 状态（补充锁屏判断）
+        if not is_locked:
+            try:
+                window_output = _run_adb_shell(device_id, "dumpsys", "window")
+                if any(
+                    x in window_output
+                    for x in (
+                        "mShowingLockscreen=true",
+                        "mDreamingLockscreen=true",
+                        "isStatusBarKeyguard=true",
+                    )
+                ):
+                    is_locked = True
+            except Exception:
+                pass
+
+        return screen_on, is_locked
+    except Exception:
+        # 检测失败：保守认为需要唤醒+解锁
+        return False, True
+
+
+def ensure_device_awake(device_id: str | None) -> None:
+    """
+    屏幕守护：在截图/动作执行前调用，必要时唤醒与解锁。
+
+    - 仅当当前线程通过 set_screen_guard_config() 开启 enabled 后生效
+    - 失败会抛异常，让上层任务尽快以明确原因失败（避免“黑屏乱点”）
+    """
+    config = get_screen_guard_config()
+    if not config or not config.enabled:
+        return
+
+    screen_on, is_locked = _is_screen_locked(device_id)
+
+    # 唤醒（仅在息屏时）
+    if config.wake and not screen_on:
+        logger.info("[ScreenGuard] Screen off detected, waking device...")
+        if config.wake_command:
+            # 用 sh -c 支持带空格的自定义命令
+            _run_adb_shell(device_id, "sh", "-c", config.wake_command)
+        else:
+            _run_adb_shell(device_id, "input", "keyevent", "KEYCODE_WAKEUP")
+        time.sleep(0.3)
+        screen_on, is_locked = _is_screen_locked(device_id)
+
+    # 解锁（仅在锁屏时）
+    if config.unlock and is_locked:
+        if not config.unlock_type:
+            raise RuntimeError("屏幕守护已开启，但未配置解锁方式（swipe/longpress）")
+        if config.unlock_start_x is None or config.unlock_start_y is None:
+            raise RuntimeError("屏幕守护已开启，但未配置解锁起点坐标")
+
+        start_x = config.unlock_start_x
+        start_y = config.unlock_start_y
+        duration = int(config.unlock_duration or 300)
+
+        if config.unlock_type == "swipe":
+            end_x = config.unlock_end_x if config.unlock_end_x is not None else start_x
+            end_y = config.unlock_end_y if config.unlock_end_y is not None else start_y
+        elif config.unlock_type == "longpress":
+            end_x = start_x
+            end_y = start_y
+        else:
+            raise RuntimeError(f"不支持的解锁方式: {config.unlock_type}")
+
+        max_retries = 3
+        for attempt in range(max_retries):
+            logger.info("[ScreenGuard] Device locked, unlocking... (%d/%d)", attempt + 1, max_retries)
+            _run_adb_shell(
+                device_id,
+                "input",
+                "swipe",
+                str(start_x),
+                str(start_y),
+                str(end_x),
+                str(end_y),
+                str(duration),
+            )
+            time.sleep(0.5)
+            _, still_locked = _is_screen_locked(device_id)
+            if not still_locked:
+                return
+            if attempt < max_retries - 1:
+                time.sleep(0.5)
+
+        raise RuntimeError(f"设备解锁失败：重试 {max_retries} 次后仍处于锁屏状态")
+

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -60,6 +60,7 @@ import {
   QrCode,
   RotateCw,
   Link,
+  Shield,
 } from 'lucide-react'
 
 // API 配置组件
@@ -292,6 +293,7 @@ function DeviceSettings() {
   const [configFormData, setConfigFormData] = useState<DeviceConfigUpdate>({
     wake_enabled: true,
     wake_command: '',
+    screen_guard_enabled: false,
     unlock_enabled: false,
     unlock_type: undefined,
     unlock_start_x: undefined,
@@ -531,6 +533,7 @@ function DeviceSettings() {
       setConfigFormData({
         wake_enabled: existingConfig.wake_enabled,
         wake_command: existingConfig.wake_command || '',
+        screen_guard_enabled: existingConfig.screen_guard_enabled ?? false,
         unlock_enabled: existingConfig.unlock_enabled,
         unlock_type: existingConfig.unlock_type || undefined,
         unlock_start_x: existingConfig.unlock_start_x ?? undefined,
@@ -543,6 +546,7 @@ function DeviceSettings() {
       setConfigFormData({
         wake_enabled: true,
         wake_command: '',
+        screen_guard_enabled: false,
         unlock_enabled: false,
         unlock_type: undefined,
         unlock_start_x: undefined,
@@ -721,6 +725,12 @@ function DeviceSettings() {
                         </p>
                         {deviceConfig && (
                           <div className="flex gap-1 mt-1">
+                            {deviceConfig.screen_guard_enabled && (
+                              <Badge variant="outline" className="text-xs">
+                                <Shield className="h-3 w-3 mr-1" />
+                                守护
+                              </Badge>
+                            )}
                             {deviceConfig.wake_enabled && (
                               <Badge variant="outline" className="text-xs">
                                 <Power className="h-3 w-3 mr-1" />
@@ -878,6 +888,27 @@ function DeviceSettings() {
             <DialogTitle>设备唤醒解锁配置</DialogTitle>
           </DialogHeader>
           <form onSubmit={handleConfigSubmit} className="space-y-6">
+            {/* 屏幕守护 */}
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <Shield className="h-5 w-5" />
+                  <Label className="text-base font-medium">屏幕守护</Label>
+                </div>
+                <Switch
+                  checked={configFormData.screen_guard_enabled}
+                  onCheckedChange={(checked) =>
+                    setConfigFormData({ ...configFormData, screen_guard_enabled: checked })
+                  }
+                />
+              </div>
+              <div className="pl-7">
+                <p className="text-xs text-muted-foreground">
+                  开启后，在每次截图前与动作执行前自动检测屏幕状态，必要时唤醒/解锁，避免模型响应慢导致熄屏后动作失败
+                </p>
+              </div>
+            </div>
+
             {/* 唤醒配置 */}
             <div className="space-y-4">
               <div className="flex items-center justify-between">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -219,6 +219,7 @@ export interface DeviceConfig {
   device_serial: string
   wake_enabled: boolean
   wake_command: string | null
+  screen_guard_enabled: boolean
   unlock_enabled: boolean
   unlock_type: 'swipe' | 'longpress' | null
   unlock_start_x: number | null
@@ -234,6 +235,7 @@ export interface DeviceConfigCreate {
   device_serial: string
   wake_enabled?: boolean
   wake_command?: string
+  screen_guard_enabled?: boolean
   unlock_enabled?: boolean
   unlock_type?: 'swipe' | 'longpress'
   unlock_start_x?: number
@@ -246,6 +248,7 @@ export interface DeviceConfigCreate {
 export interface DeviceConfigUpdate {
   wake_enabled?: boolean
   wake_command?: string
+  screen_guard_enabled?: boolean
   unlock_enabled?: boolean
   unlock_type?: 'swipe' | 'longpress'
   unlock_start_x?: number


### PR DESCRIPTION
## 背景 / 问题
  当前任务只在开始前唤醒/解锁一次。模型推理或网络波动导致「截图 → 等模型返回 → 执行动作」这段时间变长时，屏幕可能再次熄灭/回到锁屏，随后动作会落在黑屏/锁屏界面上，导致
  任务失败。

  ## 做了什么
  增加“屏幕守护”能力（可配置，默认关闭）：
  - 在 **每次截图前** 和 **每次动作执行前** 自动检测屏幕状态
  - 若检测到息屏则唤醒，若检测到锁屏则按配置执行解锁（swipe/longpress）
  - 无法解锁时明确报错，避免黑屏乱点

  ## 实现方式
  - 设备配置新增字段：`screen_guard_enabled`
  - 通过 monkey patch 在 `phone_agent` 的关键点插入守护钩子（截图前/动作执行前）
  - 守护逻辑使用 ADB `dumpsys` 检测 + `KEYCODE_WAKEUP` + `input swipe` 解锁
  - 兼容 Docker 远程 ADB server（遵循 `ADB_SERVER_SOCKET`）

  ## 如何验证
  1. 进入「设置 → 设备 → 配置」，开启“屏幕守护”
  2. 同时按设备实际情况配置“唤醒/解锁”（解锁需要坐标）
  3. 运行一个模型响应较慢的任务，观察即使中途熄屏也能自动恢复继续执行